### PR TITLE
Return nil when buffer is not initialized

### DIFF
--- a/pkg/jitter/packet_buffer.go
+++ b/pkg/jitter/packet_buffer.go
@@ -55,5 +55,9 @@ func (p *PacketBuffer) Get() ([]byte, bool, int64) {
 	p.Lock()
 	defer p.Unlock()
 
+	if p.buffer == nil {
+		return nil, false, 0
+	}
+
 	return p.buffer.Get()
 }


### PR DESCRIPTION
- 콜서버에서 아래의 경우 Jitter nil pointer exception 발생하는 문제 수정

1. 인바운드 콜 인입
2. session ticker 동작 시작 (20ms)
3. webRTC 연결, EarlyMedia 연결 등 작업 수행
4. triggerStart -> triggerWelcome 에 의해 Welcome state 도착
5. Welcome TTS 재생 시작

위와 같은 일련의 과정 중 2 -> 5 로 넘어가는 시점에서 문제 발생
VoIP 는 아직 연결되지 않아서 `jitter put()` 이 호출되지 않음 (`jitter put` 이 호출되지 않으면, jitter buffer 가 초기화 되지 않음)
이때 session ticker 에 의해 `jitter get()` 이 호출되고, nil exception 발생